### PR TITLE
add File class

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+    
       - uses: actions/checkout@v2
 
       - name: Prepare for cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,15 @@ script:
 jobs:
   include:
     - env: CIP_TAG=static
-    - env: CIP_TAG=5.31
-    - env: CIP_TAG=5.30
-    - env: CIP_TAG=5.30-buster-arm64v8
+    - env: CIP_TAG=5.33
+    - env: CIP_TAG=5.32
+    - env: CIP_TAG=5.32-buster-arm64v8
       arch: arm64
-    - env: CIP_TAG=5.30-buster32
-    - env: CIP_TAG=5.30-threads
-    - env: CIP_TAG=5.30-longdouble
-    - env: CIP_TAG=5.30-quadmath
+    - env: CIP_TAG=5.32-buster32
+    - env: CIP_TAG=5.32-threads
+    - env: CIP_TAG=5.32-longdouble
+    - env: CIP_TAG=5.32-quadmath
+    - env: CIP_TAG=5.30
     - env: CIP_TAG=5.28
     - env: CIP_TAG=5.26
     - env: CIP_TAG=5.24

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{$dist->name}}},
 
 {{$NEXT}}
   - Move to PerlFFI org (gh#37)
+  - Add FFI::C::File class (gh#38)
 
 0.08      2020-05-12 19:20:26 -0400
   - Added enum method to FFI::C (gh#23, gh#36)

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for {{$dist->name}}},
 {{$NEXT}}
   - Move to PerlFFI org (gh#37)
   - Add FFI::C::File class (gh#38)
+  - Add FFI::C::PosixFile class (gh#38)
 
 0.08      2020-05-12 19:20:26 -0400
   - Added enum method to FFI::C (gh#23, gh#36)

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ So-called "pass-by-value" is not and will not be supported.  For
 - [FFI::C::Array](https://metacpan.org/pod/FFI::C::Array)
 - [FFI::C::ArrayDef](https://metacpan.org/pod/FFI::C::ArrayDef)
 - [FFI::C::Def](https://metacpan.org/pod/FFI::C::Def)
+- [FFI::C::File](https://metacpan.org/pod/FFI::C::File)
 - [FFI::C::Struct](https://metacpan.org/pod/FFI::C::Struct)
 - [FFI::C::StructDef](https://metacpan.org/pod/FFI::C::StructDef)
 - [FFI::C::Union](https://metacpan.org/pod/FFI::C::Union)

--- a/lib/FFI/C.pm
+++ b/lib/FFI/C.pm
@@ -260,6 +260,8 @@ So-called "pass-by-value" is not and will not be supported.  For
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/Array.pm
+++ b/lib/FFI/C/Array.pm
@@ -135,6 +135,8 @@ sub CLEAR
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/ArrayDef.pm
+++ b/lib/FFI/C/ArrayDef.pm
@@ -215,6 +215,8 @@ sub create
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/Def.pm
+++ b/lib/FFI/C/Def.pm
@@ -439,6 +439,8 @@ sub rev { shift->{rev} }
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/FFI.pm
+++ b/lib/FFI/C/FFI.pm
@@ -57,6 +57,8 @@ sub memset ($$$)
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/File.pm
+++ b/lib/FFI/C/File.pm
@@ -98,7 +98,7 @@ exact format of C<$mode>.
 
 =cut
 
-my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+our $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
 $ffi->type( 'object(FFI::C::File)' => 'FILE' );
 
 $ffi->attach( fopen => [ 'string', 'string' ] => 'opaque' => sub {

--- a/lib/FFI/C/File.pm
+++ b/lib/FFI/C/File.pm
@@ -1,0 +1,309 @@
+package FFI::C::File;
+
+use strict;
+use warnings;
+use Carp qw( croak );
+use FFI::Platypus 1.00;
+
+# ABSTRACT: Perl interface to C File pointer
+# VERSION
+
+=head1 SYNOPSIS
+
+ use FFI::C::File;
+ 
+ my $file1 = FFI::C::File->fopen("foo.txt", "w");
+ my $content1 = "hello world!\n";
+ $file1->fwrite(\$content1, length $content);
+ $file1->fclose;
+ 
+ my $file2 = FFI::C::File->fopen("foo.txt", "r");
+ # take gets the file pointer, $file2 is no longer
+ # usable.
+ my $ptr = $file2->take;
+ 
+ # reconstitute the File object using the same file
+ # pointer
+ my $file3 = FFI::C::File->new($ptr);
+ my $content3 = "\0" x length $content;
+ $file3->fread(\$content3, length $content);
+ print $content3;  # "hello world!\n";
+
+=head1 DESCRIPTION
+
+This class provides an interface to the standard C library file pointers.  Normally from Perl
+you want to use the native Perl file interfaces, but sometimes you might be working with a
+C library that uses C library file pointers (anytime you see the C<FILE*> type this is the case),
+and having C native interface can be useful.
+
+For example, if you have a C function that takes a file pointer:
+
+ void foo(FILE *fp);
+
+You can use it from your Perl code like so:
+
+ use FFI::Platypus 1.00;
+ use FFI::C::File;
+ 
+ my $ffi = FFI::Platypus->new( api => 1 );
+ $ffi->attach( foo => ['object(FFI::C::File)'] );
+ 
+ my $file = FFI::C::File->fopen("foo.txt", "r");
+ foo($file);
+
+As long as this class "owns" the file pointer it will close it automatically when it falls
+out of scope.  If the C API you are calling is taking ownership of the file pointer and is
+expected to close the file itself, then you can use the take method to take the file pointer.
+Once this method is called, the file object is no longer usable (though it can be
+later reconstituted using the C<new> constructor).
+
+ use FFI::Platypus 1.00;
+ use FFI::C::File;
+ 
+ my $ffi = FFI::Platypus->new( api => 1 );
+ $ffi->attach( foo => ['opaque'] );
+ 
+ my $file = FFI::C::File->fopen("foo.txt", "r");
+ my $ptr = $file->ptr;
+ foo($ptr);
+
+Likewise, if a C API returns a file pointer that you are expected to close you can create
+a new File object from the opaque pointer using the C<new> constructor.  C:
+
+ FILE *bar();
+
+Perl:
+
+ use FFI::Platypus 1.00;
+ use FFI::C::File;
+ 
+ my $ffi = FFI::Platypus->new( api => 1 );
+ $ffi->attach( bar => [] => 'opaque' );
+ 
+ my $ptr = bar();
+ my $file = FFI::C::File->new($ptr);
+ # can now read/write etc to/from $file
+
+Constructors and methods will throw an exception on errors.  End-of-File (EOF) is not considered
+an error.
+
+=head1 CONSTRUCTOR
+
+=head2 fopen
+
+ my $file = FFI::C::File->fopen($filename, $mode);
+
+Opens the file with the given mode.  See your standard library C documentation for the
+exact format of C<$mode>.
+
+=cut
+
+my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+$ffi->type( 'object(FFI::C::File)' => 'FILE' );
+
+$ffi->attach( fopen => [ 'string', 'string' ] => 'opaque' => sub {
+  my($xsub, $class, $filename, $mode) = @_;
+  my $ptr = $xsub->($filename, $mode);
+  unless(defined $ptr)
+  {
+    croak "Error opening $filename with mode $mode: $!";
+  }
+  bless \$ptr, $class;
+});
+
+=head2 new
+
+ my $file = FFI::C::File->new($ptr);
+
+Create a new File instance object from the opaque pointer.  Note that it isn't possible
+to do any error checking on the type, so make sure that the pointer you are providing
+really is a C file pointer.
+
+=cut
+
+sub new
+{
+  my($class, $ptr) = @_;
+  bless \$ptr, $class;
+}
+
+=head1 METHODS
+
+=head2 freopen
+
+ $file->freopen($filename, $mode);
+
+Re-open the file stream.  If C<$filename> is C<undef>, then the same file is reopened.
+This can be useful for reopening a file in a different mode.  Note that the mode
+changes that are allowed are platform dependent.
+
+=cut
+
+$ffi->attach( freopen => ['string','string','FILE'] => 'opaque' => sub {
+  my($xsub, $self, $filename, $mode) = @_;
+  if(my $ptr = $xsub->($filename, $mode, $self))
+  {
+    $$self = $ptr;
+  }
+  else
+  {
+    $$self = undef;
+    $filename = 'undef' unless defined $filename;
+    croak "Error opening $filename with mode $mode: $!";
+  }
+});
+
+=head2 fread
+
+ my $bytes = $file->fread(\$buffer, $size);
+
+Read up to C<$size> bytes into C<$buffer>.  C<$buffer> must be preallocated, otherwise
+memory corruption will happen.  Returns the number of bytes actually read, which may
+be fewer than the number of bytes requested if the end of file is reached.
+
+=cut
+
+sub _read_write_wrapper
+{
+  my($xsub, $self, $buffer, $size) = @_;
+  $self->clearerr;
+  my $ret = $xsub->($$buffer, 1, $size, $self);
+  if($ret != $size)
+  {
+    if(my $error = $self->ferror)
+    {
+      croak "File error: $!";
+    }
+  }
+  return $ret;
+}
+
+$ffi->attach( fread => ['string', 'size_t', 'size_t', 'FILE'] => 'size_t' => \&_read_write_wrapper );
+
+=head2 fwrite
+
+ my $bytes = $file->fwrite(\$buffer, $size);
+
+Write up to C<$size> bytes from C<$buffer>.  Returns the number of bytes actually written.
+
+=cut
+
+$ffi->attach( fwrite => ['string', 'size_t', 'size_t', 'FILE'] => 'size_t' => \&_read_write_wrapper );
+
+=head2 fflush
+
+ $file->fflush;
+
+Flush the file stream.
+
+=cut
+
+$ffi->attach( fflush => ['FILE'] => 'int' => sub {
+  my($xsub, $self) = @_;
+  my $ret = $xsub->($self);
+  die 'fixme' unless $ret == 0;
+  return;
+});
+
+=head2 clearerr
+
+ $file->clearerr;
+
+Clear the error flag for the file stream.
+
+=cut
+
+$ffi->attach( clearerr => ['FILE'] );
+
+=head2 feof
+
+ my $bool = $file->feof;
+
+Returns true if the end of file has been reached.  False otherwise.
+
+=cut
+
+$ffi->attach( feof => ['FILE'] => 'int' );
+
+=head2 ferror
+
+ my $error = $file->ferror;
+
+Returns the file error code.
+
+=cut
+
+$ffi->attach( ferror => ['FILE'] => 'int' );
+
+=head2 take
+
+ my $ptr = $file->take;
+
+Takes ownership of the file from the object and returns the opaque file pointer.
+
+=cut
+
+sub take
+{
+  my($self) = @_;
+  my $ptr = $$self;
+  $$self = undef;
+  $ptr;
+}
+
+=head2 fclose
+
+ $file->close;
+
+Close the file.
+
+=cut
+
+$ffi->attach( fclose => [ 'FILE' ] => 'int' => sub {
+  my($xsub, $self) = @_;
+  my $ret = $xsub->($self);
+  if($ret != 0)
+  {
+    croak "Error closing file: $!";
+  }
+  $$self = undef;
+});
+
+sub DESTROY
+{
+  my($self) = @_;
+  $self->fclose if defined $$self;
+}
+
+
+1;
+
+=head1 SEE ALSO
+
+=over 4
+
+=item L<FFI::C>
+
+=item L<FFI::C::Array>
+
+=item L<FFI::C::ArrayDef>
+
+=item L<FFI::C::Def>
+
+=item L<FFI::C::File>
+
+=item L<FFI::C::Struct>
+
+=item L<FFI::C::StructDef>
+
+=item L<FFI::C::Union>
+
+=item L<FFI::C::UnionDef>
+
+=item L<FFI::C::Util>
+
+=item L<FFI::Platypus::Record>
+
+=back
+
+=cut

--- a/lib/FFI/C/PosixFile.pm
+++ b/lib/FFI/C/PosixFile.pm
@@ -1,0 +1,119 @@
+package FFI::C::PosixFile;
+
+use strict;
+use warnings;
+use Carp qw( croak );
+use base qw( FFI::C::File );
+
+# ABSTRACT: Perl interface to C File pointer with POSIX extensions
+# VERSION
+
+=head1 SYNOPSIS
+
+ use FFI::C::PosixFile;
+
+=head1 DESCRIPTION
+
+This is a subclass of L<FFI::C::File> which adds a couple of useful POSIX extensions that
+may not be available on non-POSIX systems.  Trying to create an instance of this class will
+fail on platforms that do not support the extensions.
+
+=head1 CONSTRUCTOR
+
+=head2 fopen
+
+ my $file = FFI::C::PosixFile->fopen($filename, $mode);
+
+Opens the file with the given mode.  See your standard library C documentation for the
+exact format of C<$mode>.
+
+=head2 new
+
+ my $file = FFI::C::PosixFile->new($ptr);
+
+Create a new File instance object from the opaque pointer.  Note that it isn't possible
+to do any error checking on the type, so make sure that the pointer you are providing
+really is a C file pointer.
+
+=head2 fdopen
+
+ my $file = FFI::C::PosixFile->fdopen($fd, $mode);
+
+Create a new File instance from a POSIX file descriptor.
+
+=cut
+
+our $ffi = $FFI::C::File::ffi;
+
+if($ffi->find_symbol('fdopen') && $ffi->find_symbol('fileno'))
+{
+
+  $ffi->attach( fdopen => [ 'int', 'string' ] => 'opaque' => sub {
+    my($xsub, $class, $fd, $mode) = @_;
+    if(my $ptr = $xsub->($fd, $mode))
+    {
+      return bless \$ptr, $class;
+    }
+    else
+    {
+      croak "Error opening fd $fd with mode $mode: $!";
+    }
+  });
+
+=head1 METHODS
+
+=head2 fileno
+
+ my $fd = $file->fileno;
+
+Returns the POSIX file descriptor for the file pointer.
+
+=cut
+
+  $ffi->attach( fileno => [ 'FILE' ] => 'int' );
+
+}
+else
+{
+  require Sub::Install;
+  foreach my $ctor (qw( fopen freopen new fdopen ))
+  {
+    Sub::Install::install_sub({
+      code => sub { croak "FFI::C::PosixFile not supported on this platform"; },
+      into => __PACKAGE__,
+      as   => $ctor,
+    });
+  }
+}
+
+1;
+
+=head1 SEE ALSO
+
+=over 4
+
+=item L<FFI::C>
+
+=item L<FFI::C::Array>
+
+=item L<FFI::C::ArrayDef>
+
+=item L<FFI::C::Def>
+
+=item L<FFI::C::File>
+
+=item L<FFI::C::Struct>
+
+=item L<FFI::C::StructDef>
+
+=item L<FFI::C::Union>
+
+=item L<FFI::C::UnionDef>
+
+=item L<FFI::C::Util>
+
+=item L<FFI::Platypus::Record>
+
+=back
+
+=cut

--- a/lib/FFI/C/Struct.pm
+++ b/lib/FFI/C/Struct.pm
@@ -209,6 +209,8 @@ sub CLEAR
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/StructDef.pm
+++ b/lib/FFI/C/StructDef.pm
@@ -398,6 +398,8 @@ sub trim_string { shift->{trim_string} }
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/Union.pm
+++ b/lib/FFI/C/Union.pm
@@ -41,6 +41,8 @@ Creates a new instance of the C<union>.
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/UnionDef.pm
+++ b/lib/FFI/C/UnionDef.pm
@@ -68,6 +68,8 @@ You can optionally initialize member values using C<%init>.
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/lib/FFI/C/Util.pm
+++ b/lib/FFI/C/Util.pm
@@ -209,6 +209,8 @@ sub set_array_count ($$)
 
 =item L<FFI::C::Def>
 
+=item L<FFI::C::File>
+
 =item L<FFI::C::Struct>
 
 =item L<FFI::C::StructDef>

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -18,6 +18,7 @@ $modules{$_} = $_ for qw(
   FFI::Platypus::Record
   FFI::Platypus::Type::Enum
   Math::Int64
+  Path::Tiny
   Ref::Util
   Sub::Identify
   Sub::Install
@@ -67,7 +68,7 @@ if(@keys > 0)
   spacer;
 }
 
-diag sprintf $format, 'perl ', $];
+diag sprintf $format, 'perl', "$] $^O $Config{archname}";
 
 foreach my $module (sort @modules)
 {

--- a/t/ffi_c_file.t
+++ b/t/ffi_c_file.t
@@ -101,6 +101,25 @@ subtest 'freopen' => sub {
 
 };
 
+subtest 'fseek / ftell / rewind' => sub {
+
+  my $file = FFI::C::File->fopen(__FILE__, "r");
+  is $file->ftell, 0;
+  $file->fseek(0, 'end');
+  cmp_ok $file->ftell, '>', 0;
+
+  note "ftell = ", $file->ftell;
+
+  $file->fseek(0, 'set');
+  is $file->ftell, 0;
+  $file->fseek(10, 'cur');
+  is $file->ftell, 10;
+  $file->fseek(-5, 'cur');
+  is $file->ftell, 5;
+  $file->rewind;
+  is $file->ftell, 0;
+};
+
 subtest 'exceptions' => sub {
 
   is dies { FFI::C::File->fopen("bogus.txt", "r") }, match qr/^Error opening bogus\.txt with mode r:/;

--- a/t/ffi_c_file.t
+++ b/t/ffi_c_file.t
@@ -1,0 +1,110 @@
+use Test2::V0 -no_srand => 1;
+use FFI::C::File;
+use Path::Tiny qw( path tempfile );
+
+subtest 'basic read' => sub {
+
+  my $expected = path(__FILE__)->slurp_raw;
+  my $bytes    = length($expected);
+
+  subtest 'explicit close' => sub {
+
+    my $file = FFI::C::File->fopen(__FILE__, "r");
+    isa_ok $file, 'FFI::C::File';
+
+    is( $file->feof, F() );
+
+    my $content = "\0" x $bytes;
+    is( $file->fread(\$content, $bytes), $bytes );
+    is( $content, $expected );
+
+    is( $file->feof, F() );
+
+    is( $file->fread(\$content, $bytes), 0 );
+    is( $file->feof, T() );
+
+    $file->fclose;
+
+  };
+
+  subtest 'implicit close' => sub {
+
+    my $file = FFI::C::File->fopen(__FILE__, "r");
+    isa_ok $file, 'FFI::C::File';
+
+    my $content = "\0" x $bytes;
+    is( $file->fread(\$content, $bytes), $bytes );
+    is( $content, $expected );
+
+  };
+
+  subtest 'take / new' => sub {
+
+    my $file = FFI::C::File->fopen(__FILE__, "r");
+    isa_ok $file, 'FFI::C::File';
+
+    my $ptr = $file->take;
+    undef $file;
+    $file = FFI::C::File->new($ptr);
+    isa_ok $file, 'FFI::C::File';
+
+    my $content = "\0" x $bytes;
+    is( $file->fread(\$content, $bytes), $bytes );
+    is( $content, $expected );
+
+  };
+
+};
+
+subtest 'basic write' => sub {
+
+  my $path = tempfile;
+
+  my $content = "hello world\0there";
+  my $bytes = length $content;
+
+  my $file = FFI::C::File->fopen("$path", "w");
+  is($file->fwrite(\$content, $bytes), $bytes);
+  $file->fflush;
+
+  is($path->slurp_raw, $content);
+
+};
+
+subtest 'freopen' => sub {
+
+  my $path1 = tempfile;
+  my $path2 = tempfile;
+
+  my $file = FFI::C::File->fopen("$path1", "a");
+  $file->fwrite(\"foo", 3);
+
+  $file->freopen("$path2", "a");
+  $file->fwrite(\"bar", 3);
+
+  if($^O eq 'MSWin32')
+  {
+    $file->fflush;
+    is($path1->slurp_raw, "foo");
+    is($path2->slurp_raw, "bar");
+  }
+  else
+  {
+    $file->freopen(undef, "a");
+    $file->fwrite(\"baz", 3);
+    $file->fflush;
+    is($path1->slurp_raw, "foo");
+    is($path2->slurp_raw, "barbaz");
+  }
+
+  is dies { $file->freopen("bogus.txt", "r") }, match qr/^Error opening bogus\.txt with mode r:/;
+
+};
+
+subtest 'exceptions' => sub {
+
+  is dies { FFI::C::File->fopen("bogus.txt", "r") }, match qr/^Error opening bogus\.txt with mode r:/;
+
+};
+
+done_testing;

--- a/t/ffi_c_posixfile.t
+++ b/t/ffi_c_posixfile.t
@@ -1,0 +1,29 @@
+use Test2::V0 -no_srand => 1;
+use FFI::C::PosixFile;
+
+skip_all 'Test requires POSIX extensions to libc File pointers'
+  unless FFI::C::PosixFile->can('fileno');
+
+subtest 'fileno' => sub {
+
+  my $file = FFI::C::PosixFile->fopen(__FILE__, "r");
+  isa_ok $file,  'FFI::C::File';
+  isa_ok $file,  'FFI::C::PosixFile';
+  is $file->fileno, match qr/^[0-9]+$/;
+};
+
+subtest 'fdopen' => sub {
+
+  my $file = FFI::C::PosixFile->fdopen(0, 'r');
+  isa_ok $file,  'FFI::C::File';
+  isa_ok $file,  'FFI::C::PosixFile';
+  is $file->fileno, 0;
+
+  $file = FFI::C::PosixFile->fdopen(1, 'w');
+  isa_ok $file,  'FFI::C::File';
+  isa_ok $file,  'FFI::C::PosixFile';
+  is $file->fileno, 1;
+
+};
+
+done_testing;


### PR DESCRIPTION
This provides an interface to the `stdio.h` `FILE*` pointer object from Perl.  Normally you would want to use the native Perl interfaces for manipulating files, but some C APIs use `FILE*` pointers, and this module will provider a convenient interface for working with these objects.